### PR TITLE
fix: handle null query in searchByTitle — closes #3

### DIFF
--- a/src/main/java/com/lab/library/service/BookService.java
+++ b/src/main/java/com/lab/library/service/BookService.java
@@ -4,6 +4,7 @@ import com.lab.library.model.Book;
 import com.lab.library.repository.BookRepository;
 import java.util.List;
 import java.util.Optional;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 public class BookService {
@@ -46,8 +47,12 @@ public class BookService {
     }
 
     public List<Book> searchByTitle(String query) {
+        if (query == null) {
+            return Collections.emptyList();
+        }
+        String lowerQuery = query.toLowerCase();
         return repository.findAll().stream()
-                .filter(b -> b.getTitle().toLowerCase().contains(query.toLowerCase()))
+                .filter(b -> b.getTitle() != null && b.getTitle().toLowerCase().contains(lowerQuery))
                 .collect(Collectors.toList());
     }
 

--- a/src/test/java/com/lab/library/service/BookServiceTest.java
+++ b/src/test/java/com/lab/library/service/BookServiceTest.java
@@ -51,6 +51,12 @@ class BookServiceTest {
         assertTrue(results.isEmpty());
     }
 
+    @Test
+    void searchByTitle_nullQuery_returnsEmpty() {
+        List<?> results = service.searchByTitle(null);
+        assertTrue(results.isEmpty());
+    }
+
     // TODO (Phase 4): Add a test for searchByTitle with a null query.
     // Currently it throws NullPointerException — after your fix it should
     // return an empty list. Ask your AI agent to help write this test.


### PR DESCRIPTION
Return empty list when query is null and guard against null book titles. Adds unit test for null query.