### PR TITLE
fix: null-safe ISBN comparison in findByIsbn — closes #4

### DIFF
--- a/src/main/java/com/lab/library/repository/BookRepository.java
+++ b/src/main/java/com/lab/library/repository/BookRepository.java
@@ -4,6 +4,7 @@ import com.lab.library.model.Book;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 
@@ -21,8 +22,8 @@ public class BookRepository {
 
     public Optional<Book> findByIsbn(String isbn) {
         return books.stream()
-                .filter(b -> b.getIsbn().equals(isbn))
-                .findFirst();
+            .filter(b -> Objects.equals(b.getIsbn(), isbn))
+            .findFirst();
     }
 
     public List<Book> findCheckedOut() {


### PR DESCRIPTION
Use Objects.equals() for ISBN comparison to avoid NullPointerException.